### PR TITLE
2.1.1   add event / page to breadcrumb for single speakers/sessions/keynotes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This allows for _correctly_ saving bidirectional relationships between speakers 
 * Paul van Buuren: paul@wbvb.nl
 
 ## Current version:
-2.0.6 - Remove white background for taxonomy description.
+2.1.1 - Add event / page to breadcrumb for single speakers/sessions/keynotes.
 
 ## Version history
+* 2.1.1 - Add event / page to breadcrumb for single speakers/sessions/keynotes.
 * 2.0.6 - Remove white background for taxonomy description.
 * 2.0.5 - Fixed small HTML error, fixed small PHP errors.
 * 2.0.4 - Small CSS changes to adapt to 2021 styling of old theme. 

--- a/acf-json/group_5d9b3421a5abc.json
+++ b/acf-json/group_5d9b3421a5abc.json
@@ -72,7 +72,7 @@
             "key": "field_633b15ddcfc28",
             "label": "Inschrijfpagina",
             "name": "themesettings_conference_event",
-            "type": "post_object",
+            "type": "relationship",
             "instructions": "selecteer hier het event (of de pagina) waar bezoekers zich kunnen inschrijven voor de conferentie",
             "required": 0,
             "conditional_logic": 0,
@@ -86,10 +86,15 @@
                 "event"
             ],
             "taxonomy": "",
-            "allow_null": 0,
-            "multiple": 0,
-            "return_format": "object",
-            "ui": 1
+            "filters": [
+                "search",
+                "post_type",
+                "taxonomy"
+            ],
+            "elements": "",
+            "min": "",
+            "max": 1,
+            "return_format": "object"
         },
         {
             "key": "field_616862bb5b7bf",
@@ -138,5 +143,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1664816672
+    "modified": 1664819529
 }

--- a/css/frontend-conf.css
+++ b/css/frontend-conf.css
@@ -7,8 +7,8 @@
 // @package   ictuwp-plugin-conference
 // @author    Paul van Buuren
 // @license   GPL-2.0+
-// @version   2.0.6
-// @desc.     Remove white background for taxonomy description.
+// @version   2.1.1
+// @desc.     Add event / page to breadcrumb for single speakers/sessions/keynotes.
 // @link      https://github.com/ICTU/Gebruiker-Centraal---Inclusie---custom-post-types-taxonomies
 
 

--- a/less/frontend-conf.less
+++ b/less/frontend-conf.less
@@ -7,8 +7,8 @@
 // @package   ictuwp-plugin-conference
 // @author    Paul van Buuren
 // @license   GPL-2.0+
-// @version   2.0.6
-// @desc.     Remove white background for taxonomy description.
+// @version   2.1.1
+// @desc.     Add event / page to breadcrumb for single speakers/sessions/keynotes.
 // @link      https://github.com/ICTU/Gebruiker-Centraal---Inclusie---custom-post-types-taxonomies
 
 


### PR DESCRIPTION
Deze PR voegt een extra veld toe aan de site-instellingen, namelijk 'Inschrijfpagina'. De pagina of het event dat je hiermee selecteert wordt toegevoegd aan de breadcrumb, als je kijkt naar een bijv. een spreker of het overzicht van sprekers.